### PR TITLE
Title margins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+components/

--- a/example.html
+++ b/example.html
@@ -10,7 +10,7 @@
         }
     </style>
     <link href="build/build.css" rel="stylesheet" type="text/css"/>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto:300,500,700" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400=|Roboto:300,400,700" rel="stylesheet" type="text/css">
 </head>
 <body class="v2-copy">
 

--- a/example.html
+++ b/example.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head lang="en">
+    <meta charset="UTF-8">
+    <title>Typography</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+        }
+    </style>
+    <link href="build/build.css" rel="stylesheet" type="text/css"/>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Roboto:300,500,700" rel="stylesheet" type="text/css">
+</head>
+<body class="v2-copy">
+
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur finibus volutpat elit ut porta. Aliquam ullamcorper vestibulum aliquet. Nunc sodales nunc non dui congue lacinia. Integer vitae mi nisi. Donec rhoncus, dolor eget posuere semper, nunc massa dapibus dolor, vulputate laoreet diam ante at arcu. Aenean sed dolor porttitor tellus consequat cursus et et lacus. Praesent vulputate molestie rhoncus. Etiam porta mattis dui, vitae elementum magna scelerisque eget. Phasellus venenatis, nibh et fringilla cursus, nulla libero auctor orci, at bibendum nibh eros et diam. Cras sit amet rutrum velit. Mauris odio nisl, sollicitudin at placerat sed, congue sit amet purus. Vivamus ut consequat ex.</p>
+    <h1 class="v2-title v2-title--1">Title 1</h1>
+    <h2 class="v2-title v2-title--2">Title 2</h2>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur finibus volutpat elit ut porta. Aliquam ullamcorper vestibulum aliquet. Nunc sodales nunc non dui congue lacinia. Integer vitae mi nisi. Donec rhoncus, dolor eget posuere semper, nunc massa dapibus dolor, vulputate laoreet diam ante at arcu. Aenean sed dolor porttitor tellus consequat cursus et et lacus. Praesent vulputate molestie rhoncus. Etiam porta mattis dui, vitae elementum magna scelerisque eget. Phasellus venenatis, nibh et fringilla cursus, nulla libero auctor orci, at bibendum nibh eros et diam. Cras sit amet rutrum velit. Mauris odio nisl, sollicitudin at placerat sed, congue sit amet purus. Vivamus ut consequat ex.</p>
+    <h3 class="v2-title v2-title--3">Title 3</h3>
+    <h4 class="v2-title v2-title--4">Title 4</h4>
+    <p>Aliquam est elit, pharetra vitae orci eget, accumsan rutrum massa. Fusce volutpat ornare placerat. Nulla et est fringilla, dignissim nisi commodo, fringilla augue. Ut in massa sodales diam semper rutrum non non turpis. Etiam tempus pretium ultrices. Morbi justo mi, vehicula sit amet justo non, varius malesuada magna. Integer vel tellus quis nisi mattis aliquam sed vel diam. Integer mollis nisi sed fermentum scelerisque. Sed pharetra nunc sed tincidunt finibus. Nam eu sollicitudin nulla. Ut pharetra in metus in varius. Etiam posuere ligula ex, eu rhoncus leo scelerisque ut. Aliquam sollicitudin erat quis elit bibendum maximus. Aliquam a libero quam. Phasellus congue maximus ex in lobortis.</<p>
+    <p>Morbi tristique, purus vitae rutrum sodales, ligula nulla feugiat odio, at placerat dolor lectus sed lacus. Sed porta turpis sed ipsum scelerisque, vitae accumsan justo egestas. Pellentesque at scelerisque nunc. Cras congue, erat et viverra lobortis, velit elit imperdiet lacus, vitae viverra leo turpis in nisl. Donec tempus laoreet mauris, vel blandit elit lobortis id. Suspendisse sed lorem auctor, ornare nibh a, hendrerit est. Fusce nec eros non justo semper vehicula ut vel tellus. Nunc venenatis erat lacus, iaculis commodo dolor commodo sollicitudin. In tempor ex et maximus accumsan. Praesent nec odio hendrerit, elementum elit quis, varius lorem. Suspendisse eu tellus in nulla interdum sodales a non turpis. Pellentesque sed hendrerit dui. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Etiam lacinia tempor orci, quis porttitor risus viverra non. Pellentesque ullamcorper, dolor nec ultrices ultrices, quam tortor fermentum lacus, nec convallis ante mi a elit. In rutrum eros ac molestie placerat.</p>
+    <p>Vivamus eleifend accumsan elit ac euismod. Nunc varius porttitor mollis. Vivamus sed dui vitae lorem auctor viverra nec vel nisl. Pellentesque vehicula magna quis dapibus sollicitudin. Phasellus dictum id nisi nec dictum. Phasellus eu posuere quam. Vivamus id nunc vel lorem bibendum maximus quis vitae diam. Curabitur ac scelerisque dui. Etiam sit amet consequat ante. Nullam et ullamcorper lacus, quis luctus mauris. Aliquam facilisis dui vitae mi imperdiet auctor. In in enim eros. Aliquam eget turpis sit amet metus aliquet sagittis ac quis mi.</p>
+    <p>Donec elementum libero purus, sit amet laoreet nibh commodo vitae. Maecenas in ligula iaculis, interdum lectus id, lobortis arcu. Proin nisl purus, mattis at suscipit eu, ultrices ac elit. Nam lectus turpis, hendrerit ut interdum pretium, placerat id neque. Phasellus consequat eget quam quis ultrices. Nulla condimentum imperdiet vehicula. Curabitur dignissim urna nunc. Fusce sodales tellus nec diam aliquet ultricies. Sed et dui vel massa dapibus aliquet. Proin elementum ultricies neque sit amet vestibulum. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam bibendum vel lacus in pharetra. Donec tristique arcu ac volutpat vestibulum. Sed consequat orci vel lectus scelerisque, sed eleifend quam aliquet. Curabitur sollicitudin eget leo ac porta. Fusce congue augue non metus posuere, eget maximus augue mollis.</p>
+
+</body>
+</html>

--- a/lib/copy.css
+++ b/lib/copy.css
@@ -6,3 +6,8 @@
   font-weight: 400;
   line-height: 22px;
 }
+
+.v2-paragraph {
+  margin-top: 15px;
+  margin-bottom: 20px;
+}

--- a/lib/copy.css
+++ b/lib/copy.css
@@ -8,6 +8,6 @@
 }
 
 .v2-paragraph {
-  margin-top: 15px;
-  margin-bottom: 20px;
+  margin-top: 10px;
+  margin-bottom: 10px;
 }

--- a/lib/titles.css
+++ b/lib/titles.css
@@ -5,20 +5,23 @@
 }
 
 .v2-title--1 {
-  margin-bottom: 40px;
+  margin-top: 60px;
+  margin-bottom: 30px;
   font-size: 54px;
   letter-spacing: -2px;
   line-height: 60px;
 }
 
 .v2-title--2 {
-  margin-bottom: 20px;
+  margin-top: 50px;
+  margin-bottom: 25px;
   font-size: 36px;
   letter-spacing: -1px;
   line-height: 48px;
 }
 
 .v2-title--3 {
+  margin-top: 40px;
   margin-bottom: 20px;
   font-size: 24px;
   letter-spacing: -1px;
@@ -26,7 +29,8 @@
 }
 
 .v2-title--4 {
-  margin-bottom: 5px;
+  margin-top: 30px;
+  margin-bottom: 15px;
   font-size: 18px;
   font-weight: 400;
   line-height: 24px;

--- a/lib/titles.css
+++ b/lib/titles.css
@@ -6,7 +6,7 @@
 
 .v2-title--1 {
   margin-top: 60px;
-  margin-bottom: 30px;
+  margin-bottom: 25px;
   font-size: 54px;
   letter-spacing: -2px;
   line-height: 60px;
@@ -14,7 +14,7 @@
 
 .v2-title--2 {
   margin-top: 50px;
-  margin-bottom: 25px;
+  margin-bottom: 20px;
   font-size: 36px;
   letter-spacing: -1px;
   line-height: 48px;
@@ -22,7 +22,7 @@
 
 .v2-title--3 {
   margin-top: 40px;
-  margin-bottom: 20px;
+  margin-bottom: 15px;
   font-size: 24px;
   letter-spacing: -1px;
   line-height: 32px;


### PR DESCRIPTION
The most controversial style is the v2-paragraph which needs to be applied to <p> tags in body copy to inherit the correct margins for body copy. We chose not to apply the styles to `.v2-copy p` because this breaks all the things… for example:

<div class=v2-copy>

<p>Some normal copy text</p>

<div class=card>
	<p class=card__desc>A description with specific margins (card might be a fixed height object) will have its margins overridden by `.v2-copy p` because it has a higher level of specificity (a class AND an element opposed to just a class)</p>
</div>

</div>

If we really don’t want to put v2-paragraph everywhere, then we’d need to be careful where we put v2-copy classes (atm they seem to be put round the body level) and have to manually apply copy styles (font family, weight and size) to `card`s. 

We don’t seem to have too much copy so it shouldn’t be too hard to add v2-paragraph as we’re creating pages

Thoughts?
