### PR TITLE
Add font-display: swap

### DIFF
--- a/mixins/copy.scss
+++ b/mixins/copy.scss
@@ -2,6 +2,7 @@
 @mixin copy-common() {
   font-family: $font-copy;
   font-weight: 400;
+  font-display: swap;
   line-height: 1.43; //20px at 14px
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nib-styles/v2-typography",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "repository": {
     "type": "git",
     "url": "git@github.com:nib-styles/v2-typography.git"


### PR DESCRIPTION
Improves browser handling of web font swap from fallback to webfont. Only in chrome and opera currently.

More info https://css-tricks.com/the-critical-request/#article-header-id-4